### PR TITLE
Parse reverse complement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
         	<groupId>org.sbolstandard</groupId>
         	<artifactId>libSBOLj</artifactId>
-        	<version>2.3.1</version>
+        	<version>2.4.0</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/knox/spring/data/neo4j/controller/KnoxController.java
+++ b/src/main/java/knox/spring/data/neo4j/controller/KnoxController.java
@@ -5,11 +5,8 @@ import java.io.InputStream;
 import java.util.*;
 
 import knox.spring.data.neo4j.domain.DesignSpace;
+import knox.spring.data.neo4j.exception.*;
 import knox.spring.data.neo4j.sample.DesignSampler.EnumerateType;
-import knox.spring.data.neo4j.exception.DesignSpaceBranchesConflictException;
-import knox.spring.data.neo4j.exception.DesignSpaceConflictException;
-import knox.spring.data.neo4j.exception.DesignSpaceNotFoundException;
-import knox.spring.data.neo4j.exception.ParameterEmptyException;
 import knox.spring.data.neo4j.sbol.SBOLConversion;
 import knox.spring.data.neo4j.services.DesignSpaceService;
 
@@ -654,7 +651,7 @@ public class KnoxController {
     	
     	try {
 			designSpaceService.importSBOL(sbolDocs, outputSpaceID);
-		} catch (IOException | SBOLValidationException | SBOLConversionException e) {
+		} catch (IOException | SBOLValidationException | SBOLConversionException | SBOLException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}

--- a/src/main/java/knox/spring/data/neo4j/domain/Edge.java
+++ b/src/main/java/knox/spring/data/neo4j/domain/Edge.java
@@ -573,7 +573,7 @@ public class Edge {
             setOrientation(Orientation.REVERSE_COMPLEMENT);
         }
 
-        if(isReverseComplement()){
+        else if(isReverseComplement()){
             setOrientation(Orientation.INLINE);
         }
     }

--- a/src/main/java/knox/spring/data/neo4j/domain/Edge.java
+++ b/src/main/java/knox/spring/data/neo4j/domain/Edge.java
@@ -529,6 +529,7 @@ public class Edge {
     public enum Orientation {
         INLINE("inline"),
         REVERSE_COMPLEMENT("reverseComplement"),
+        UNDECLARED("undeclared"), //means it can be inline or reverse
         NONE("none");
 
         private final String value;

--- a/src/main/java/knox/spring/data/neo4j/domain/Edge.java
+++ b/src/main/java/knox/spring/data/neo4j/domain/Edge.java
@@ -31,16 +31,14 @@ public class Edge {
     ArrayList<String> componentIDs;
     
     ArrayList<String> componentRoles;
-    
-    String orientation;
+
+    Orientation orientation;
 
     double weight;
     
     private static final Logger LOG = LoggerFactory.getLogger(Edge.class);
 
-    public Edge() {
-        
-    }
+    public Edge() {}
 
     public Edge(Node tail, Node head) {
         this.tail = tail;
@@ -51,13 +49,13 @@ public class Edge {
         
         componentRoles = new ArrayList<String>();
         
-        orientation = Orientation.NONE.getValue();
+        orientation = Orientation.NONE;
         
         weight = 1.0;
     }
     
     public Edge(Node tail, Node head, ArrayList<String> componentIDs, 
-            ArrayList<String> componentRoles) {
+                ArrayList<String> componentRoles) {
         this.tail = tail;
         
         this.head = head;
@@ -67,16 +65,16 @@ public class Edge {
         this.componentRoles = componentRoles;
         
         if (!this.componentIDs.isEmpty() || !this.componentRoles.isEmpty()) {
-            orientation = Orientation.INLINE.getValue();
+            orientation = Orientation.INLINE;
         } else {
-            orientation = Orientation.NONE.getValue();
+            orientation = Orientation.NONE;
         }
         
         weight = 1.0;
     }
     
     public Edge(Node tail, Node head, ArrayList<String> componentIDs, 
-            ArrayList<String> componentRoles, String orientation) {
+                ArrayList<String> componentRoles, Orientation orientation) {
         this.tail = tail;
         
         this.head = head;
@@ -88,14 +86,14 @@ public class Edge {
         if (!this.componentIDs.isEmpty() || !this.componentRoles.isEmpty()) {
             this.orientation = orientation;
         } else {
-            this.orientation = Orientation.NONE.getValue();
+            this.orientation = Orientation.NONE;
         }
         
         weight = 1.0;
     }
     
     public Edge(Node tail, Node head, ArrayList<String> componentIDs, 
-            ArrayList<String> componentRoles, String orientation, double weight) {
+            ArrayList<String> componentRoles, Orientation orientation, double weight) {
         this.tail = tail;
 
         this.head = head;
@@ -107,14 +105,14 @@ public class Edge {
         if (!this.componentIDs.isEmpty() || !this.componentRoles.isEmpty()) {
             this.orientation = orientation;
         } else {
-            this.orientation = Orientation.NONE.getValue();
+            this.orientation = Orientation.NONE;
         }
 
         this.weight = weight;
     }
     
-    public Edge(ArrayList<String> componentIDs, ArrayList<String> componentRoles, String orientation, 
-            double weight) {
+    public Edge(ArrayList<String> componentIDs, ArrayList<String> componentRoles,
+                Orientation orientation, double weight) {
         this.componentIDs = componentIDs;
 
         this.componentRoles = componentRoles;
@@ -122,7 +120,7 @@ public class Edge {
         if (!this.componentIDs.isEmpty() || !this.componentRoles.isEmpty()) {
             this.orientation = orientation;
         } else {
-            this.orientation = Orientation.NONE.getValue();
+            this.orientation = Orientation.NONE;
         }
 
         this.weight = weight;
@@ -130,17 +128,17 @@ public class Edge {
     
     public Edge copy() {
         return new Edge(new ArrayList<String>(componentIDs),
-                new ArrayList<String>(componentRoles), orientation, weight);
+                new ArrayList<>(componentRoles), orientation, weight);
     }
     
     public Edge copy(Node head) {
         return new Edge(tail, head, new ArrayList<String>(componentIDs),
-                new ArrayList<String>(componentRoles), orientation, weight);
+                new ArrayList<>(componentRoles), orientation, weight);
     }
 
     public Edge copy(Node tail, Node head) {
         return new Edge(tail, head, new ArrayList<String>(componentIDs),
-                new ArrayList<String>(componentRoles), orientation, weight);
+                new ArrayList<>(componentRoles), orientation, weight);
     }
     
     public void delete() {
@@ -335,14 +333,6 @@ public class Edge {
         return componentRoles != null && !componentRoles.isEmpty();
     }
     
-    public boolean hasOrientation() {
-        return isInline() || isReverseComplement();
-    }
-    
-    public boolean hasOrientation(String orientation) {
-        return hasOrientation() && this.orientation.equals(orientation);
-    }
-    
     public void intersectWithEdge(Edge edge, int tolerance) {
         // Map other component IDs to roles and other component roles to IDs
         
@@ -503,14 +493,6 @@ public class Edge {
         }
     }
     
-    public boolean isInline() {
-        return orientation.equals(Orientation.INLINE.getValue());
-    }
-    
-    public boolean isReverseComplement() {
-        return orientation.equals(Orientation.REVERSE_COMPLEMENT.getValue());
-    }
-    
     public boolean isBlank() {
         return !hasComponentIDs() && !hasComponentRoles() && !hasOrientation();
     }
@@ -525,10 +507,6 @@ public class Edge {
 
     public void setTail(Node tail) { 
         this.tail = tail; 
-    }
-    
-    public String getOrientation() {
-        return orientation;
     }
 
     public void setWeight(double weight) {
@@ -547,20 +525,55 @@ public class Edge {
         }
         
     }
-    
+
     public enum Orientation {
         INLINE("inline"),
         REVERSE_COMPLEMENT("reverseComplement"),
         NONE("none");
 
         private final String value;
-        
-        Orientation(String value) { 
+
+        Orientation(String value) {
             this.value = value;
         }
 
         public String getValue() {
-            return value; 
+            return value;
+        }
+    }
+
+    public Orientation getOrientation() {
+        return orientation;
+    }
+
+    public void setOrientation(Orientation orientation){
+        this.orientation = orientation;
+    }
+
+    public boolean hasOrientation() {
+        return isInline() || isReverseComplement();
+    }
+
+
+    public boolean hasOrientation(Orientation orientation) {
+        return hasOrientation() && this.orientation.equals(orientation);
+    }
+
+    public boolean isInline() {
+        return orientation.equals(Orientation.INLINE);
+    }
+
+    public boolean isReverseComplement() {
+        return orientation.equals(Orientation.REVERSE_COMPLEMENT);
+    }
+
+    public void reverseOrientation(){
+        if(isInline()){
+            setOrientation(Orientation.REVERSE_COMPLEMENT);
+        }
+
+        if(isReverseComplement()){
+            setOrientation(Orientation.INLINE);
         }
     }
 }

--- a/src/main/java/knox/spring/data/neo4j/domain/Node.java
+++ b/src/main/java/knox/spring/data/neo4j/domain/Node.java
@@ -80,7 +80,7 @@ public class Node {
     
     public Edge copyEdge(Edge edge, Node head) {
     	return createEdge(head, new ArrayList<String>(edge.getComponentIDs()),
-    			new ArrayList<String>(edge.getComponentRoles()), edge.getOrientation());
+    			new ArrayList<>(edge.getComponentRoles()), edge.getOrientation());
     }
 
     public Edge createEdge(Node head) {
@@ -100,7 +100,7 @@ public class Node {
     }
     
     public Edge createEdge(Node head, ArrayList<String> compIDs, ArrayList<String> compRoles,
-    		String orientation) {
+    						Edge.Orientation orientation) {
         Edge edge = new Edge(this, head, compIDs, compRoles, orientation);
         
         addEdge(edge);
@@ -278,7 +278,7 @@ public class Node {
     	return edgesWithHead;
     }
     
-    public Set<Edge> getEdges(String orientation) {
+    public Set<Edge> getEdges(Edge.Orientation orientation) {
     	Set<Edge> edgesWithHead = new HashSet<Edge>();
     	
     	if (hasEdges()) {
@@ -377,7 +377,7 @@ public class Node {
     		
     		for (Edge edge : edges) {
     			if (!edge.isBlank()) {
-    				String code = edge.getHeadID() + edge.getOrientation();
+    				String code = edge.getHeadID() + edge.getOrientation().getValue();
 
     				if (!codeToIncomingEdges.containsKey(code)) {
     					codeToIncomingEdges.put(code, new HashSet<Edge>());
@@ -388,7 +388,7 @@ public class Node {
     				List<List<Edge>> blankPaths = edge.getOrthogonalBlankPaths();
 
     				for (List<Edge> blankPath : blankPaths) {
-    					String code = blankPath.get(blankPath.size() - 1).getHead().getNodeID() + edge.getOrientation();
+    					String code = blankPath.get(blankPath.size() - 1).getHead().getNodeID() + edge.getOrientation().getValue();
 
     					if (!codeToIncomingPaths.containsKey(code)) {
     						codeToIncomingPaths.put(code, new HashSet<List<Edge>>());

--- a/src/main/java/knox/spring/data/neo4j/domain/NodeSpace.java
+++ b/src/main/java/knox/spring/data/neo4j/domain/NodeSpace.java
@@ -53,6 +53,16 @@ public class NodeSpace {
 		
 		startNode.createEdge(acceptNode, componentIDs, componentRoles);
 	}
+
+	public NodeSpace(ArrayList<String> componentIDs, ArrayList<String> componentRoles, Edge.Orientation orientation) {
+		this(0);
+
+		Node startNode = createStartNode();
+
+		Node acceptNode = createAcceptNode();
+
+		startNode.createEdge(acceptNode, componentIDs, componentRoles, orientation);
+	}
 	
 	public void addNode(Node node) {
 		if (nodes == null) {

--- a/src/main/java/knox/spring/data/neo4j/exception/SBOLException.java
+++ b/src/main/java/knox/spring/data/neo4j/exception/SBOLException.java
@@ -1,0 +1,11 @@
+package knox.spring.data.neo4j.exception;
+
+public class SBOLException extends RuntimeException{
+    private static final long serialVersionUID = 462532991641214656L;
+
+    private String message;
+
+    public SBOLException(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/knox/spring/data/neo4j/repositories/DesignSpaceRepository.java
+++ b/src/main/java/knox/spring/data/neo4j/repositories/DesignSpaceRepository.java
@@ -115,7 +115,7 @@ public interface DesignSpaceRepository extends GraphRepository<DesignSpace> {
         + "WHERE target.spaceID = {targetSpaceID} "
         +
         "RETURN target.spaceID as spaceID, m.nodeID as tailID, m.nodeTypes as tailTypes, e.componentRoles as componentRoles, "
-        + "e.componentIDs as componentIDs, n.nodeID as headID, n.nodeTypes as headTypes")
+        + "e.componentIDs as componentIDs, e.orientation as orientation, n.nodeID as headID, n.nodeTypes as headTypes")
     List<Map<String, Object>> mapDesignSpace(@Param("targetSpaceID") String targetSpaceID);
 
     @Query("MATCH (n:DesignSpace) RETURN n.spaceID;")

--- a/src/main/java/knox/spring/data/neo4j/sample/DesignSampler.java
+++ b/src/main/java/knox/spring/data/neo4j/sample/DesignSampler.java
@@ -238,7 +238,8 @@ public class DesignSampler {
 
 				comp.put("roles", edge.getComponentRoles());
 
-				comp.put("orientation", edge.getOrientation());
+//				comp.put("orientation", edge.getOrientation());
+				comp.put("orientation", edge.getOrientation().getValue()); //does this need to be string?
 
 				if (!designs.isEmpty()) {
 					for (List<Map<String, Object>> design : designs) {

--- a/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
+++ b/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
@@ -15,6 +15,7 @@ import knox.spring.data.neo4j.domain.NodeSpace;
 import knox.spring.data.neo4j.operations.JoinOperator;
 import knox.spring.data.neo4j.operations.OROperator;
 import knox.spring.data.neo4j.operations.RepeatOperator;
+import knox.spring.data.neo4j.exception.SBOLException;
 
 public class SBOLConversion {
 
@@ -35,7 +36,7 @@ public class SBOLConversion {
 	 * calls the appropriate SBOL parser by checking for CombinatorialDerivations
 	 * @return
 	 */
-	public List<DesignSpace> convertSBOLsToSpaces(){
+	public List<DesignSpace> convertSBOLsToSpaces() throws SBOLException{
 
 		List<DesignSpace> allOutputSpaces = new ArrayList<>();
 
@@ -56,7 +57,7 @@ public class SBOLConversion {
 	 * @param sbolDoc
 	 * @return list of design spaces
 	 */
-	private List<DesignSpace> convertCombinatorialSBOL(SBOLDocument sbolDoc) {
+	private List<DesignSpace> convertCombinatorialSBOL(SBOLDocument sbolDoc) throws SBOLException{
 
 		List<DesignSpace> outputSpaces = new ArrayList<>();
 		Set<CombinatorialDerivation> rootCVs = getRootCombinatorialDerivation(sbolDoc);
@@ -77,7 +78,7 @@ public class SBOLConversion {
 		return outputSpaces;
 	}
 
-	private List<NodeSpace> recurseVariableComponents(CombinatorialDerivation combinatorialDerivation){
+	private List<NodeSpace> recurseVariableComponents(CombinatorialDerivation combinatorialDerivation) throws SBOLException{
 		ComponentDefinition template = combinatorialDerivation.getTemplate();
 		List<NodeSpace> inputSpace = new LinkedList<>();
 
@@ -161,7 +162,7 @@ public class SBOLConversion {
 		return orderedVCs;
 	}
 
-	private NodeSpace createNodeSpaceFromVariableComponent(VariableComponent variableComponent, ComponentDefinition template){
+	private NodeSpace createNodeSpaceFromVariableComponent(VariableComponent variableComponent, ComponentDefinition template) throws SBOLException{
 		ArrayList<String> atomIDs = new ArrayList<>();
 		ArrayList<String> atomRoles = new ArrayList<>();
 
@@ -209,7 +210,7 @@ public class SBOLConversion {
 		if(Objects.nonNull(annotation)){
 			// throw error if there is more than one location
 			if(annotation.getLocations().size() > 1){
-				throw new RuntimeException("Cannot parse SBOL with more than one Location in SequenceAnnotation");
+				throw new SBOLException("Cannot parse SBOL with more than one Location in SequenceAnnotation");
 			}
 
 			OrientationType orientation = annotation.getLocations().iterator().next().getOrientation();

--- a/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
+++ b/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
@@ -167,16 +167,10 @@ public class SBOLConversion {
 
 		// Find variant roles
 		for (ComponentDefinition variant : variableComponent.getVariants()) {
-			if (variant.getRoles().isEmpty()) {
-				for (URI role : variable.getRoles()) {
-					atomIDs.add(variant.getIdentity().toString());
-					atomRoles.add(role.toString());
-				}
-			} else {
-				for (URI role : variant.getRoles()) {
-					atomIDs.add(variant.getIdentity().toString());
-					atomRoles.add(role.toString());
-				}
+			Set<URI> roles = variant.getRoles().isEmpty()? variable.getRoles(): variant.getRoles();
+			for (URI role : roles) {
+				atomIDs.add(variant.getIdentity().toString());
+				atomRoles.add(role.toString());
 			}
 		}
 
@@ -185,17 +179,10 @@ public class SBOLConversion {
 			for (TopLevel member: collection.getMembers()){
 				if (member.getClass() == ComponentDefinition.class){
 					ComponentDefinition def = (ComponentDefinition) member;
-					
-					if (def.getRoles().isEmpty()) {
-						for (URI role : variable.getRoles()) {
-							atomIDs.add(def.getIdentity().toString());
-							atomRoles.add(role.toString());
-						}
-					} else {
-						for (URI role : def.getRoles()) {
-							atomIDs.add(def.getIdentity().toString());
-							atomRoles.add(role.toString());
-						}
+					Set<URI> roles = def.getRoles().isEmpty()? variable.getRoles(): def.getRoles();
+					for (URI role : roles) {
+						atomIDs.add(def.getIdentity().toString());
+						atomRoles.add(role.toString());
 					}
 				}
 			}

--- a/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
+++ b/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
@@ -197,7 +197,20 @@ public class SBOLConversion {
 
 		//create space
 		List<NodeSpace> inputSpace = new LinkedList<>();
-		NodeSpace newSpace = new NodeSpace(atomIDs, atomRoles, orientation);
+		NodeSpace newSpace;
+
+		// if unspecified, create both INLINE and REVERSE
+		if(orientation == Edge.Orientation.UNDECLARED){
+			newSpace = new NodeSpace(atomIDs, atomRoles, Edge.Orientation.INLINE);
+			for(Edge edge : newSpace.getStartNode().getEdges()){
+				Edge duplicateEdge = edge.copy(edge.getTail(), edge.getHead());
+				duplicateEdge.reverseOrientation();
+				newSpace.getStartNode().addEdge(duplicateEdge);
+			}
+		} else {
+			newSpace = new NodeSpace(atomIDs, atomRoles, orientation);
+		}
+
 		inputSpace.add(newSpace);
 
 		//check operator

--- a/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
+++ b/src/main/java/knox/spring/data/neo4j/sbol/SBOLConversion.java
@@ -207,19 +207,26 @@ public class SBOLConversion {
 		SequenceAnnotation annotation = template.getSequenceAnnotation(component);
 
 		if(Objects.nonNull(annotation)){
-			// returns the first orientation it finds
-			for(Location location: annotation.getLocations()){
-				OrientationType orientation = location.getOrientation();
-				if(orientation == OrientationType.INLINE){
-					return Edge.Orientation.INLINE;
-				}
-				if(orientation == OrientationType.REVERSECOMPLEMENT){
-					return Edge.Orientation.REVERSE_COMPLEMENT;
-				}
+			// throw error if there is more than one location
+			if(annotation.getLocations().size() > 1){
+				throw new RuntimeException("Cannot parse SBOL with more than one Location in SequenceAnnotation");
+			}
+
+			OrientationType orientation = annotation.getLocations().iterator().next().getOrientation();
+
+			//if orientation does not exist, then it's implicit that the component can be inline or reverse complement
+			if(orientation == null){
+				return Edge.Orientation.UNDECLARED;
+			}
+			if(orientation == OrientationType.INLINE){
+				return Edge.Orientation.INLINE;
+			}
+			if(orientation == OrientationType.REVERSECOMPLEMENT){
+				return Edge.Orientation.REVERSE_COMPLEMENT;
 			}
 		}
 
-		return Edge.Orientation.NONE;
+		return Edge.Orientation.INLINE;
 	}
 
 	private NodeSpace applyOperator(OperatorType operator, List<NodeSpace> inputSpace){

--- a/src/main/java/knox/spring/data/neo4j/services/DesignSpaceService.java
+++ b/src/main/java/knox/spring/data/neo4j/services/DesignSpaceService.java
@@ -997,6 +997,8 @@ public class DesignSpaceService {
 	        if (row.containsKey("componentIDs") && row.get("componentIDs") != null) {
 	        	link.put("componentIDs", row.get("componentIDs"));
 	        }
+
+			link.put("orientation", row.get("orientation"));
 	        
 	        links.add(link);
 	    }

--- a/src/main/java/knox/spring/data/neo4j/services/DesignSpaceService.java
+++ b/src/main/java/knox/spring/data/neo4j/services/DesignSpaceService.java
@@ -7,10 +7,7 @@ import knox.spring.data.neo4j.domain.Edge;
 import knox.spring.data.neo4j.domain.Node;
 import knox.spring.data.neo4j.domain.NodeSpace;
 import knox.spring.data.neo4j.domain.Snapshot;
-import knox.spring.data.neo4j.exception.DesignSpaceBranchesConflictException;
-import knox.spring.data.neo4j.exception.DesignSpaceConflictException;
-import knox.spring.data.neo4j.exception.DesignSpaceNotFoundException;
-import knox.spring.data.neo4j.exception.ParameterEmptyException;
+import knox.spring.data.neo4j.exception.*;
 import knox.spring.data.neo4j.operations.ANDOperator;
 import knox.spring.data.neo4j.operations.Concatenation;
 import knox.spring.data.neo4j.operations.JoinOperator;
@@ -601,7 +598,7 @@ public class DesignSpaceService {
     }
     
     public void importSBOL(List<SBOLDocument> sbolDocs, String outputSpaceID) 
-    		throws SBOLValidationException, IOException, SBOLConversionException {
+    		throws SBOLValidationException, IOException, SBOLConversionException, SBOLException {
     	SBOLConversion sbolConv = new SBOLConversion();
 
     	sbolConv.setSbolDoc(sbolDocs);


### PR DESCRIPTION
Edge orientation information was previously not being included in the API, and therefore, not passed to the UI. This PR parses SBOL SequenceAnnotation for orientation specifications and adds it as a parameter in the D3 graph API. 

- parses explicit and implicit SBOL for edge orientation
- changed Edge orientation from String to Orientation object
   - added new constant "undeclared" for implicit orientation
- added new class for SBOLException handling
- added orientation parameter to D3 graph object 